### PR TITLE
Update query_gn.R

### DIFF
--- a/R/query_gn.R
+++ b/R/query_gn.R
@@ -12,7 +12,8 @@ query_gn <-
     result <- httr::GET(url)
     httr::stop_for_status(result)
     result <- httr::content(result, encoding=encoding, as=output)
-
+    result[unlist(lapply(result, is.null))] = NA
+        
     check_gn_error(result)
 }
 


### PR DESCRIPTION
@ameliebaud created this patch which broke a query: 

  I propose adding the line
 result[unlist(lapply(result, is.null))] = NA
because
 return(as.data.frame(result)) in list_datasets() will crash if one of the list elements is NULL so changing to NA